### PR TITLE
add certificate provider

### DIFF
--- a/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
@@ -19,6 +19,12 @@ public sealed class Certificate : Resource
 
     public bool ValidateThumbprint { get; set; }
 
+    public bool RemoteInsecure { get; set; }
+
+    public string? RemoteThumbprint { get; set; }
+
+    public string? RemoteRootThumbprint { get; set; }
+
     public Certificate(string name)
         : base(name)
     {

--- a/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
@@ -15,7 +15,7 @@ public sealed class Certificate : Resource
 
     public CertificateState Ensure { get; set; }
 
-    public string Thumbprint { get; set; } = string.Empty;
+    public string? Thumbprint { get; set; }
 
     public bool ValidateThumbprint { get; set; }
 

--- a/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
@@ -25,6 +25,14 @@ public sealed class Certificate : Resource
 
     public string? RemoteRootThumbprint { get; set; }
 
+    public string TokenScheme { get; set; } = "Bearer";
+
+    public string? Token { get; set; }
+
+    public string? Username { get; set; }
+
+    public string? Password { get; set; }
+
     public Certificate(string name)
         : base(name)
     {

--- a/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/Certificate.cs
@@ -1,0 +1,26 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using Spectre.IO;
+
+namespace Cupboard;
+
+public sealed class Certificate : Resource
+{
+    public Uri? Url { get; set; }
+
+    public FilePath? FilePath { get; set; }
+
+    public StoreLocation StoreLocation { get; set; }
+
+    public StoreName StoreName { get; set; }
+
+    public CertificateState Ensure { get; set; }
+
+    public string Thumbprint { get; set; } = string.Empty;
+
+    public bool ValidateThumbprint { get; set; }
+
+    public Certificate(string name)
+        : base(name)
+    {
+    }
+}

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateExtensions.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateExtensions.cs
@@ -14,6 +14,15 @@ public static class CertificateExtensions
     public static IResourceBuilder<Certificate> Thumbprint(this IResourceBuilder<Certificate> builder, string thumbprint) =>
         builder.Configure(cert => cert.Thumbprint = thumbprint);
 
+    public static IResourceBuilder<Certificate> RemoteInsecure(this IResourceBuilder<Certificate> builder) =>
+        builder.Configure(cert => cert.RemoteInsecure = true);
+
+    public static IResourceBuilder<Certificate> RemoteThumbprint(this IResourceBuilder<Certificate> builder, string thumbprint) =>
+        builder.Configure(cert => cert.RemoteThumbprint = thumbprint);
+
+    public static IResourceBuilder<Certificate> RemoteRootThumbprint(this IResourceBuilder<Certificate> builder, string thumbprint) =>
+        builder.Configure(cert => cert.RemoteRootThumbprint = thumbprint);
+
     public static IResourceBuilder<Certificate> FromUrl(this IResourceBuilder<Certificate> builder, string url) =>
         builder.Configure(cert => cert.Url = new Uri(url));
 

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateExtensions.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using Spectre.IO;
+
+namespace Cupboard;
+
+public static class CertificateExtensions
+{
+    public static IResourceBuilder<Certificate> Ensure(this IResourceBuilder<Certificate> builder, CertificateState state) =>
+        builder.Configure(cert => cert.Ensure = state);
+
+    public static IResourceBuilder<Certificate> ValidateThumbprint(this IResourceBuilder<Certificate> builder) =>
+        builder.Configure(cert => cert.ValidateThumbprint = true);
+
+    public static IResourceBuilder<Certificate> Thumbprint(this IResourceBuilder<Certificate> builder, string thumbprint) =>
+        builder.Configure(cert => cert.Thumbprint = thumbprint);
+
+    public static IResourceBuilder<Certificate> FromUrl(this IResourceBuilder<Certificate> builder, string url) =>
+        builder.Configure(cert => cert.Url = new Uri(url));
+
+    public static IResourceBuilder<Certificate> FromFile(this IResourceBuilder<Certificate> builder, FilePath filePath) =>
+        builder.Configure(cert => cert.FilePath = filePath);
+
+    public static IResourceBuilder<Certificate> FromUrl(this IResourceBuilder<Certificate> builder, Uri url) =>
+        builder.Configure(cert => cert.Url = url);
+
+    public static IResourceBuilder<Certificate> StoreName(this IResourceBuilder<Certificate> builder, StoreName storeName) =>
+        builder.Configure(cert => cert.StoreName = storeName);
+
+    public static IResourceBuilder<Certificate> StoreLocation(this IResourceBuilder<Certificate> builder, StoreLocation storeLocation) =>
+        builder.Configure(cert => cert.StoreLocation = storeLocation);
+}

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateExtensions.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateExtensions.cs
@@ -37,4 +37,16 @@ public static class CertificateExtensions
 
     public static IResourceBuilder<Certificate> StoreLocation(this IResourceBuilder<Certificate> builder, StoreLocation storeLocation) =>
         builder.Configure(cert => cert.StoreLocation = storeLocation);
+
+    public static IResourceBuilder<Certificate> TokenScheme(this IResourceBuilder<Certificate> builder, string scheme) =>
+        builder.Configure(cert => cert.TokenScheme = scheme);
+
+    public static IResourceBuilder<Certificate> Token(this IResourceBuilder<Certificate> builder, string token) =>
+        builder.Configure(cert => cert.Token = token);
+
+    public static IResourceBuilder<Certificate> Username(this IResourceBuilder<Certificate> builder, string username) =>
+        builder.Configure(cert => cert.Username = username);
+
+    public static IResourceBuilder<Certificate> Password(this IResourceBuilder<Certificate> builder, string password) =>
+        builder.Configure(cert => cert.Password = password);
 }

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
@@ -105,7 +105,8 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
                 };
             }
 
-            if (resource.RemoteThumbprint is not null) {
+            if (resource.RemoteThumbprint is not null)
+            {
                 handler ??= new()
                 {
                     ServerCertificateCustomValidationCallback = (_, remoteCertificate, _, _) =>
@@ -113,7 +114,8 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
                 };
             }
 
-            if (resource.RemoteRootThumbprint is not null) {
+            if (resource.RemoteRootThumbprint is not null)
+            {
                 handler ??= new()
                 {
                     ServerCertificateCustomValidationCallback = (_, _, chain, _) =>

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
@@ -121,7 +121,7 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
             return ResourceState.Unchanged;
         }
 
-        if (resource.ValidateThumbprint && resource.Thumbprint.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
+        if (resource.ValidateThumbprint && resource.Thumbprint?.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
         {
             _logger.Error($"Certificate thumbprint does not match. The provided thumbprint '{resource.Thumbprint}' is not equal to the thumbprint inside the certificate '{certificate.Thumbprint}'");
             return ResourceState.Error;
@@ -153,7 +153,7 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
             return ResourceState.Error;
         }
 
-        if (resource.ValidateThumbprint && resource.Thumbprint.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
+        if (resource.ValidateThumbprint && resource.Thumbprint?.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
         {
             _logger.Error($"Certificate thumbprint does not match. The provided thumbprint '{resource.Thumbprint}' is not equal to the thumbprint inside the certificate '{certificate.Thumbprint}'");
             return ResourceState.Error;

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
@@ -67,8 +67,8 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
         X509Certificate2? certificate = null;
         foreach (var storeCertificate in store.Certificates)
         {
-            if (storeCertificate.Thumbprint.Equals(resource.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false
-                && storeCertificate.FriendlyName.Contains(resource.Name, StringComparison.InvariantCultureIgnoreCase) is false)
+            if (storeCertificate.Thumbprint.Equals(resource.Thumbprint, StringComparison.OrdinalIgnoreCase) is false
+                && storeCertificate.FriendlyName.Contains(resource.Name, StringComparison.OrdinalIgnoreCase) is false)
             {
                 continue;
             }
@@ -121,7 +121,7 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
             return ResourceState.Unchanged;
         }
 
-        if (resource.ValidateThumbprint && resource.Thumbprint?.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
+        if (resource.ValidateThumbprint && resource.Thumbprint?.Equals(certificate.Thumbprint, StringComparison.OrdinalIgnoreCase) is false)
         {
             _logger.Error($"Certificate thumbprint does not match. The provided thumbprint '{resource.Thumbprint}' is not equal to the thumbprint inside the certificate '{certificate.Thumbprint}'");
             return ResourceState.Error;
@@ -153,7 +153,7 @@ public class CertificateProvider : AsyncResourceProvider<Certificate>
             return ResourceState.Error;
         }
 
-        if (resource.ValidateThumbprint && resource.Thumbprint?.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
+        if (resource.ValidateThumbprint && resource.Thumbprint?.Equals(certificate.Thumbprint, StringComparison.OrdinalIgnoreCase) is false)
         {
             _logger.Error($"Certificate thumbprint does not match. The provided thumbprint '{resource.Thumbprint}' is not equal to the thumbprint inside the certificate '{certificate.Thumbprint}'");
             return ResourceState.Error;

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateProvider.cs
@@ -1,0 +1,191 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using Spectre.IO;
+
+namespace Cupboard;
+
+public class CertificateProvider : AsyncResourceProvider<Certificate>
+{
+    private readonly ICupboardFileSystem _fileSystem;
+    private readonly ICupboardEnvironment _environment;
+    private readonly ICupboardLogger _logger;
+    private readonly HttpClient _http;
+
+    public CertificateProvider(
+        ICupboardFileSystem fileSystem,
+        ICupboardEnvironment environment,
+        ICupboardLogger logger)
+    {
+        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        _environment = environment;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _http = new HttpClient();
+    }
+
+    public override Certificate Create(string name)
+    {
+        return new Certificate(name);
+    }
+
+    public override async Task<ResourceState> RunAsync(IExecutionContext context, Certificate resource)
+    {
+        return resource.Ensure switch
+        {
+            CertificateState.Present => await EnsurePresent(resource, context).ConfigureAwait(false),
+            CertificateState.Absent => await EnsureAbsent(resource, context).ConfigureAwait(false),
+            _ => ResourceState.Error,
+        };
+    }
+
+    private static string ToStoreNameString(StoreName storeName)
+    {
+        return storeName switch
+        {
+            StoreName.CertificateAuthority => "Intermediate Certification Authorities",
+            StoreName.AddressBook => "Other People",
+            StoreName.AuthRoot => "Third-Party Root Certification Authorities",
+            StoreName.Disallowed => "Untrusted Certificates",
+            StoreName.My => "Personal Certificates",
+            StoreName.Root => "Trusted Root Certification Authorities",
+            StoreName.TrustedPeople => "Trusted People",
+            StoreName.TrustedPublisher => "Trusted Publisher",
+            _ => "Non existing",
+        };
+    }
+
+    private static string ToStoreLocationString(StoreLocation storeLocation)
+    {
+        return storeLocation switch
+        {
+            StoreLocation.LocalMachine => "Local Machine",
+            StoreLocation.CurrentUser => "Current User",
+            _ => "Non existing",
+        };
+    }
+
+    private X509Certificate2? FindCertificateInStore(Certificate resource, X509Store store)
+    {
+        X509Certificate2? certificate = null;
+        foreach (var storeCertificate in store.Certificates)
+        {
+            if (storeCertificate.Thumbprint.Equals(resource.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false
+                && storeCertificate.FriendlyName.Contains(resource.Name, StringComparison.InvariantCultureIgnoreCase) is false)
+            {
+                continue;
+            }
+
+            _logger.Debug("Certificate found in store based on thumbprint or name");
+            certificate = storeCertificate;
+            break;
+        }
+
+        return certificate;
+    }
+
+    private async Task<ResourceState> EnsureAbsent(Certificate resource, IExecutionContext context)
+    {
+        X509Certificate2? certificate = null;
+
+        if (resource.FilePath is not null && resource.Url is null)
+        {
+            var filePath = resource.FilePath.MakeAbsolute(_environment);
+            if (_fileSystem.Exist(filePath) is false)
+            {
+                _logger.Error("Certificate file does not exist");
+                return ResourceState.Error;
+            }
+
+            certificate = new X509Certificate2(filePath.FullPath);
+        }
+
+        if (resource.Url is not null && resource.FilePath is null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, resource.Url);
+            using var response = await _http.SendAsync(request).ConfigureAwait(false);
+            var certificateBytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            certificate = new X509Certificate2(certificateBytes);
+        }
+
+        _logger.Debug($"Opening Certificate Store: [yellow]{ToStoreNameString(resource.StoreName)}[/] Location: [yellow]{ToStoreLocationString(resource.StoreLocation)}[/]");
+        using var store = new X509Store(resource.StoreName, resource.StoreLocation);
+        store.Open(OpenFlags.ReadWrite);
+
+        certificate ??= FindCertificateInStore(resource, store);
+
+        if (certificate is null)
+        {
+            return ResourceState.Unchanged;
+        }
+
+        if (resource.ValidateThumbprint && resource.Thumbprint.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
+        {
+            _logger.Error($"Certificate thumbprint does not match. The provided thumbprint '{resource.Thumbprint}' is not equal to the thumbprint inside the certificate '{certificate.Thumbprint}'");
+            return ResourceState.Error;
+        }
+
+        if (store.Certificates.Contains(certificate) is false)
+        {
+            return ResourceState.Unchanged;
+        }
+
+        if (context.DryRun is false)
+        {
+            store.Remove(certificate);
+        }
+
+        return ResourceState.Changed;
+    }
+
+    private async Task<ResourceState> EnsurePresent(Certificate resource, IExecutionContext context)
+    {
+        X509Certificate2? certificate = null;
+        if (resource.FilePath is not null && resource.Url is null)
+        {
+            var filePath = resource.FilePath.MakeAbsolute(_environment);
+            if (_fileSystem.Exist(filePath) is false)
+            {
+                _logger.Error("Certificate file does not exist");
+                return ResourceState.Error;
+            }
+
+            certificate = new X509Certificate2(filePath.FullPath);
+        }
+
+        if (resource.Url is not null && resource.FilePath is null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, resource.Url);
+            using var response = await _http.SendAsync(request).ConfigureAwait(false);
+            var certificateBytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            certificate = new X509Certificate2(certificateBytes);
+        }
+
+        _logger.Debug($"Opening Certificate Store: [yellow]{ToStoreNameString(resource.StoreName)}[/] Location: [yellow]{ToStoreLocationString(resource.StoreLocation)}[/]");
+        using var store = new X509Store(resource.StoreName, resource.StoreLocation);
+        store.Open(OpenFlags.ReadWrite);
+
+        certificate ??= FindCertificateInStore(resource, store);
+
+        if (certificate is null)
+        {
+            _logger.Error("No certificate specified");
+            return ResourceState.Error;
+        }
+
+        if (resource.ValidateThumbprint && resource.Thumbprint.Equals(certificate.Thumbprint, StringComparison.InvariantCultureIgnoreCase) is false)
+        {
+            _logger.Error($"Certificate thumbprint does not match. The provided thumbprint '{resource.Thumbprint}' is not equal to the thumbprint inside the certificate '{certificate.Thumbprint}'");
+            return ResourceState.Error;
+        }
+
+        if (store.Certificates.Contains(certificate))
+        {
+            return ResourceState.Unchanged;
+        }
+
+        if (context.DryRun is false)
+        {
+            store.Add(certificate);
+        }
+
+        return ResourceState.Changed;
+    }
+}

--- a/src/Cupboard.Providers.Windows/Certificate/CertificateState.cs
+++ b/src/Cupboard.Providers.Windows/Certificate/CertificateState.cs
@@ -1,0 +1,7 @@
+﻿namespace Cupboard;
+
+public enum CertificateState
+{
+    Present,
+    Absent,
+}

--- a/src/Cupboard.Providers.Windows/WindowsModule.cs
+++ b/src/Cupboard.Providers.Windows/WindowsModule.cs
@@ -10,6 +10,7 @@ public sealed class WindowsModule : ServiceModule
         services.AddSingleton<IResourceProvider, WindowsFeatureProvider>();
         services.AddSingleton<IResourceProvider, RegistryValueProvider>();
         services.AddSingleton<IResourceProvider, WingetPackageProvider>();
+        services.AddSingleton<IResourceProvider, CertificateProvider>();
 
         // Facts
         services.AddSingleton<IFactProvider, WindowsFacts>();

--- a/src/Cupboard.Tests/IO/HttpClientTests.cs
+++ b/src/Cupboard.Tests/IO/HttpClientTests.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace Cupboard.Tests.Unit.IO;
+
+public class HttpClientTests
+{
+    [Fact]
+    public async Task Should_Validate_Remote_Certificate()
+    {
+        // Given
+        var handler = new HttpClientHandler
+        {
+            // Likely to become an issue in 2035 when the root certificate expires
+            ServerCertificateCustomValidationCallback = (_, _, chain, _) =>
+                chain.ChainElements[^1].Certificate.Thumbprint.Equals(
+                    "cabd2a79a1076a31f21d253635cb039d4329a5e8", StringComparison.OrdinalIgnoreCase),
+        };
+        var httpClient = new HttpClient(handler);
+        var url = new Uri("https://x1.i.lencr.org/");
+
+        // When
+        var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
+        var response = await httpClient.SendAsync(httpRequest);
+        var certificateBytes = await response.Content.ReadAsByteArrayAsync();
+        var certificate = new X509Certificate2(certificateBytes);
+
+        // Then
+        certificate.ShouldNotBeNull();
+        certificate.Verify();
+    }
+
+    [Fact]
+    public async Task Should_Not_Validate_Remote_Certificate()
+    {
+        // Given
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+                chain.ChainElements[^1].Certificate.Thumbprint.Equals(
+                    "NotValid", StringComparison.OrdinalIgnoreCase),
+        };
+        var httpClient = new HttpClient(handler);
+        var url = new Uri("https://x1.i.lencr.org/");
+
+        // When
+        var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
+        var action = async () => await httpClient.SendAsync(httpRequest);
+
+        // Then
+        await action.ShouldThrowAsync<HttpRequestException>();
+    }
+}

--- a/src/Sandbox/Manifests/EnsureCertificates.cs
+++ b/src/Sandbox/Manifests/EnsureCertificates.cs
@@ -1,0 +1,27 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using Cupboard;
+
+namespace Sandbox;
+
+public sealed class EnsureCertificates : Manifest
+{
+    public override void Execute(ManifestContext context)
+    {
+        context.Resource<Certificate>("DST Root CA X3")
+            .Thumbprint("dac9024f54d8f6df94935fb1732638ca6ad77c13")
+            .ValidateThumbprint()
+            .Ensure(CertificateState.Absent)
+            .StoreName(StoreName.Root)
+            .StoreLocation(StoreLocation.LocalMachine)
+            .RequireAdministrator();
+
+        context.Resource<Certificate>("ISRG Root X1")
+            .Thumbprint("cabd2a79a1076a31f21d253635cb039d4329a5e8")
+            .ValidateThumbprint()
+            .FromUrl("http://x1.i.lencr.org/") // use HTTP since HTTPS uses the ISRG Root X1 in the chain 😮
+            .Ensure(CertificateState.Present)
+            .StoreName(StoreName.Root)
+            .StoreLocation(StoreLocation.LocalMachine)
+            .RequireAdministrator();
+    }
+}

--- a/src/Sandbox/Manifests/EnsureCertificates.cs
+++ b/src/Sandbox/Manifests/EnsureCertificates.cs
@@ -17,8 +17,9 @@ public sealed class EnsureCertificates : Manifest
 
         context.Resource<Certificate>("ISRG Root X1")
             .Thumbprint("cabd2a79a1076a31f21d253635cb039d4329a5e8")
+            .RemoteRootThumbprint("cabd2a79a1076a31f21d253635cb039d4329a5e8") // Validate the https://x1.i.lencr.org/ root certificate
             .ValidateThumbprint()
-            .FromUrl("http://x1.i.lencr.org/") // use HTTP since HTTPS uses the ISRG Root X1 in the chain 😮
+            .FromUrl("https://x1.i.lencr.org/")
             .Ensure(CertificateState.Present)
             .StoreName(StoreName.Root)
             .StoreLocation(StoreLocation.LocalMachine)


### PR DESCRIPTION
Thought it might be useful to have an certificate provider 😁

~Some improvements would be to create our own enum for store name as the symbol naming is not that great.~
:shrug: 

~Would be nice to have the option for HTTP client to disable certificate checks because of bad certificate chain as seen with the recent DST Root CA X3 cert expiration 😅~
Done

~I could foresee it get somewhat complicated with password and etc but should be doable, this was an initial attempt at making sure root certificate could get patched.~
Done

We have some systems that do not have general internet access.

Could potentially also be a separate nuget package if you feel it adds too much.

Haven't gotten around to tests, would like to pick your brain on how we could test the functionality.
Perhaps creating an interface for the certificate store so it could be mocked? As it often requires administrator.