### PR TITLE
Refactor Chmod implementation to use UnixFileMode and remove Mono.Posix dependency

### DIFF
--- a/src/Cupboard.Core/Cupboard.Core.csproj
+++ b/src/Cupboard.Core/Cupboard.Core.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.6.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="Spectre.IO" Version="0.18.0" />
   </ItemGroup>

--- a/src/Cupboard.Core/Extensions/PathExtensions.cs
+++ b/src/Cupboard.Core/Extensions/PathExtensions.cs
@@ -12,7 +12,6 @@ public static class PathExtensions
             return;
         }
 
-        var info = UnixFileSystemInfo.GetFileSystemEntry(path.FullPath);
-        info.FileAccessPermissions = chmod.ToFileAccessPermissions();
+        File.SetUnixFileMode(path.FullPath, chmod.ToFileAccessPermissions());
     }
 }

--- a/src/Cupboard.Core/IO/Chmod.cs
+++ b/src/Cupboard.Core/IO/Chmod.cs
@@ -3,7 +3,7 @@ namespace Cupboard;
 [PublicAPI]
 public sealed class Chmod
 {
-    private static readonly Dictionary<Func<Chmod, Permissions>, Dictionary<Permissions, FileAccessPermissions>> _lookup;
+    private static readonly Dictionary<Func<Chmod, Permissions>, Dictionary<Permissions, UnixFileMode>> _lookup;
 
     public SpecialMode Mode { get; }
     public Permissions Owner { get; }
@@ -12,25 +12,25 @@ public sealed class Chmod
 
     static Chmod()
     {
-        _lookup = new Dictionary<Func<Chmod, Permissions>, Dictionary<Permissions, FileAccessPermissions>>
+        _lookup = new()
         {
             [c => c.Owner] = new()
             {
-                { Permissions.Read, FileAccessPermissions.UserRead },
-                { Permissions.Write, FileAccessPermissions.UserWrite },
-                { Permissions.Execute, FileAccessPermissions.UserExecute },
+                { Permissions.Read, UnixFileMode.UserRead },
+                { Permissions.Write, UnixFileMode.UserWrite },
+                { Permissions.Execute, UnixFileMode.UserExecute },
             },
             [c => c.Group] = new()
             {
-                { Permissions.Read, FileAccessPermissions.GroupRead },
-                { Permissions.Write, FileAccessPermissions.GroupWrite },
-                { Permissions.Execute, FileAccessPermissions.GroupExecute },
+                { Permissions.Read, UnixFileMode.GroupRead },
+                { Permissions.Write, UnixFileMode.GroupWrite },
+                { Permissions.Execute, UnixFileMode.GroupExecute },
             },
             [c => c.Other] = new()
             {
-                { Permissions.Read, FileAccessPermissions.OtherRead },
-                { Permissions.Write, FileAccessPermissions.OtherWrite },
-                { Permissions.Execute, FileAccessPermissions.OtherExecute },
+                { Permissions.Read, UnixFileMode.OtherRead },
+                { Permissions.Write, UnixFileMode.OtherWrite },
+                { Permissions.Execute, UnixFileMode.OtherExecute },
             },
         };
     }
@@ -64,9 +64,9 @@ public sealed class Chmod
         };
     }
 
-    public FileAccessPermissions ToFileAccessPermissions()
+    public UnixFileMode ToFileAccessPermissions()
     {
-        var permissions = default(FileAccessPermissions);
+        var permissions = default(UnixFileMode);
         foreach (var map in _lookup)
         {
             var permission = map.Key(this);

--- a/src/Cupboard.Core/Properties/Usings.cs
+++ b/src/Cupboard.Core/Properties/Usings.cs
@@ -2,7 +2,6 @@ global using System.Collections;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
 global using JetBrains.Annotations;
-global using Mono.Unix;
 global using Spectre.Console.Cli;
 global using Spectre.IO;
 

--- a/src/Cupboard.Tests/IO/ChmodTests.cs
+++ b/src/Cupboard.Tests/IO/ChmodTests.cs
@@ -15,9 +15,9 @@ public sealed class ChmodTests
 
             // Then
             result.ShouldBe(
-                FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite | FileAccessPermissions.UserExecute |
-                FileAccessPermissions.GroupRead | FileAccessPermissions.GroupWrite |
-                FileAccessPermissions.OtherRead | FileAccessPermissions.OtherWrite);
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
         }
 
         [Fact]
@@ -30,11 +30,10 @@ public sealed class ChmodTests
             var result = chmod.ToFileAccessPermissions();
 
             // Then
-            result.ShouldBe(FileAccessPermissions.DefaultPermissions);
             result.ShouldBe(
-                FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite |
-                FileAccessPermissions.GroupRead | FileAccessPermissions.GroupWrite |
-                FileAccessPermissions.OtherRead | FileAccessPermissions.OtherWrite);
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
         }
     }
 

--- a/src/Cupboard.Tests/Properties/Usings.cs
+++ b/src/Cupboard.Tests/Properties/Usings.cs
@@ -1,7 +1,6 @@
 global using System.Runtime.InteropServices;
 global using Cupboard.Testing;
 global using Microsoft.Extensions.DependencyInjection;
-global using Mono.Unix;
 global using NSubstitute;
 global using Shouldly;
 global using Spectre.IO;

--- a/src/Cupboard/Properties/Usings.cs
+++ b/src/Cupboard/Properties/Usings.cs
@@ -13,7 +13,6 @@ global using JetBrains.Annotations;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Win32;
-global using Mono.Unix.Native;
 global using Spectre.Console;
 global using Spectre.Console.Cli;
 global using Spectre.Console.Rendering;

--- a/src/Cupboard/SecurityPrincipal.cs
+++ b/src/Cupboard/SecurityPrincipal.cs
@@ -12,6 +12,6 @@ internal sealed class SecurityPrincipal : ISecurityPrincipal
             RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
                 ? new WindowsPrincipal(WindowsIdentity.GetCurrent())
                     .IsInRole(WindowsBuiltInRole.Administrator)
-                : Syscall.geteuid() == 0);
+                : System.Environment.IsPrivilegedProcess);
     }
 }


### PR DESCRIPTION
[Environment.IsPrivilegedProcess](https://github.com/dotnet/runtime/blob/60b84bb13e499e0866731dbe21973b92b7abed15/src/libraries/System.Private.CoreLib/src/System/Environment.cs#L50C28-L61) calls [IsPrivilegedProcessCore](https://github.com/dotnet/runtime/blob/60b84bb13e499e0866731dbe21973b92b7abed15/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs#L29) which calls `Interop.Sys.GetEUid() == 0` on unix 

We could properly use the same method for Windows although we are not checking if we are administrator, it checks if the token is elevated:
https://github.com/dotnet/runtime/blob/60b84bb13e499e0866731dbe21973b92b7abed15/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L89-L115

The reason to remove this dependency is it carries around a libMonoPosixHelper.so/dylib/dll which is unnecessary for the functionality that we need. Which can be solved entirely in the BCL.

`SetUnixFileMode` was added in .NET 7